### PR TITLE
Pscott/linux vpage chunking

### DIFF
--- a/ci/flake8.cfg
+++ b/ci/flake8.cfg
@@ -8,23 +8,23 @@ select =
     T,
     S,
 ignore = 
-    E501,  # Line too long
-    E251,  # unexpected spaces around keyword / parameter equals
-    E266,  # too many leading '#' for block comment
-    W293,  # blank line contains whitespace
-    E302,  # expected 2 blank lines, found 1
-    E261,  # at least two spaces before inline comment
-    E202,  # whitespace before ']'
-    E201,  # whitespace after '['
-    W291,  # trailing whitespace
-    E203,  # whitespace before :
-    E265,  # block comment should start with '# '
-    E303,  # too many blank lines (2)
-    E225,  # missing whitespace around operator
-    W503,  # line break before binary operator
-    S108,  # insecure use of temp file/dir, noisy and not a big deal for us
-    S404,  # need to allow subprocess
-    S603,  # need to allow subprocess
-    F403,  # Unable to detect undefined names due to * import
+    E501,
+    E251,
+    E266,
+    W293, 
+    E302,
+    E261,
+    E202,
+    E201,
+    W291,
+    E203,
+    E265,
+    E303,
+    E225,
+    W503,
+    S108,
+    S404,
+    S603,
+    F403,
 application_import_names = celery_worker,config,main,api,config,core,model,tasks,tests,upgrades,var,workers
 import-order-style=pep8

--- a/varc_core/systems/base_system.py
+++ b/varc_core/systems/base_system.py
@@ -53,6 +53,7 @@ class BaseSystem:
         self.extract_dumps = extract_dumps
         self.include_memory = include_memory
         self.include_open = include_open
+        self.screenshot = take_screenshot
 
         if self.process_name and self.process_id:
             raise ValueError(
@@ -242,7 +243,7 @@ class BaseSystem:
                 logging.info("Adding Netstat Data")
                 with zip_file.open("netstat.log", 'w') as network_file:
                     network_file.write("\r\n".join(self.network_log).encode())
-            if self.dump_loaded_files:
+            if self.include_open and self.dumped_files:
                 for file_path in self.dumped_files:
                     logging.info(f"Adding open file {file_path}")
                     try:

--- a/varc_core/systems/base_system.py
+++ b/varc_core/systems/base_system.py
@@ -224,18 +224,18 @@ class BaseSystem:
         table_data["processes"] = self.dict_to_json(self.process_info)
         open_files_dict = [{"Open File": open_file} for open_file in self.dumped_files]
         table_data["open_files"] = self.dict_to_json(open_files_dict)
-        if self.take_screenshot:
-            screenshot = self.take_screenshot()
+        if self.screenshot:
+            screenshot_image = self.take_screenshot()
         else:
-            screenshot = None
+            screenshot_image = None
         if not output_path:
             output_path = os.path.join("", f"{self.get_machine_name()}-{self.timestamp}.zip")
         # strip .zip if in filename as shutil appends to end
         archive_out = output_path + ".zip" if not output_path.endswith(".zip") else output_path
         self.output_path = output_path
         with zipfile.ZipFile(archive_out, 'a', compression=zipfile.ZIP_DEFLATED) as zip_file:
-            if screenshot:
-                zip_file.writestr(f"{self.get_machine_name()}-{self.timestamp}.png", screenshot)
+            if screenshot_image:
+                zip_file.writestr(f"{self.get_machine_name()}-{self.timestamp}.png", screenshot_image)
             for key, value in table_data.items():
                 with zip_file.open(f"{key}.json", 'w') as json_file:
                     json_file.write(value.encode())

--- a/varc_core/systems/linux.py
+++ b/varc_core/systems/linux.py
@@ -39,6 +39,7 @@ class LinuxSystem(BaseSystem):
         ]
         self.process_vm_readv.restype = ctypes.c_ssize_t
         if self.include_memory:
+            self._MAX_VIRTUAL_PAGE_CHUNK = 256 * 1000**2 # set max number of megabytes that will be read at a time
             self.dump_processes()
             if self.extract_dumps:
                 from varc_core.utils import dumpfile_extraction

--- a/varc_core/systems/linux.py
+++ b/varc_core/systems/linux.py
@@ -107,9 +107,21 @@ class LinuxSystem(BaseSystem):
                             for map in maps:
                                 page_start = map[0]
                                 page_len = map[1] - map[0]
-                                mem_page_content = self.read_bytes(pid, page_start, page_len)
-                                if mem_page_content:
-                                    tmpfile.write(mem_page_content)
+                                if page_len > self._MAX_VIRTUAL_PAGE_CHUNK:
+                                    sub_chunk_count, final_chunk_size = divmod(page_len, self._MAX_VIRTUAL_PAGE_CHUNK)
+                                    page_len = int(page_len / sub_chunk_count)
+                                    for sc in range(0, sub_chunk_count):
+                                        mem_page_content = self.read_bytes(pid, page_start, page_len)
+                                        if mem_page_content:
+                                            tmpfile.write(mem_page_content)
+                                        page_start = page_start + self._MAX_VIRTUAL_PAGE_CHUNK
+                                    mem_page_content = self.read_bytes(pid, page_start, final_chunk_size)
+                                    if mem_page_content:
+                                        tmpfile.write(mem_page_content)
+                                else:
+                                    mem_page_content = self.read_bytes(pid, page_start, page_len)
+                                    if mem_page_content:
+                                        tmpfile.write(mem_page_content)
                             zip_file.write(tmpfile.name, f"process_dumps{sep}{p_name}_{pid}.mem")
                         except PermissionError:
                             logging.warning(f"Permission denied opening process memory for {p_name} (pid {pid}). Cannot dump this process.")


### PR DESCRIPTION
Adding a limit on how much memory will be read at a time in Linux to avoid large vpages causing excessive memory use and crashing the collection. Default value set to 256MB. Change was tested by putting a system under synthetic memory pressure where a single vpage to be read is larger than current free memory and collecting all processes.