### PR TITLE
Allow varc to output as tar.lz4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pymem==1.8.5
 python-magic==0.4.24
 pyinstaller # dont set a version, not compatible
 yara-python==4.3.1
+lz4==4.3.3

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -8,12 +8,11 @@ from varc_core.systems import BaseSystem
 
 class TestImport(unittest.TestCase):
     system: BaseSystem
-    zip_path: str
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.system = acquire_system()
-        cls.zip_path = cls.system.acquire_volatile()
+        cls.system.acquire_volatile()
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -29,5 +28,5 @@ class TestImport(unittest.TestCase):
 
     def test_got_files(self) -> None:
         # Check we got atleast 10 files
-        with ZipFile(self.zip_path) as z:
+        with ZipFile(self.system.output_path) as z:
             self.assertGreater(len(z.namelist()), 10)

--- a/tests/test_linux/test_base.py
+++ b/tests/test_linux/test_base.py
@@ -5,17 +5,12 @@ from varc_core.systems import BaseSystem, acquire_system
 
 class TestBaseCases(unittest.TestCase):
     system: BaseSystem
-    zip_path: str
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.system = acquire_system()
-        cls.zip_path = cls.system.acquire_volatile()
+        cls.system.acquire_volatile()
 
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        pass
 
     def test_some_processes(self) -> None:
         processes = self.system.get_processes()
@@ -28,7 +23,7 @@ class TestBaseCases(unittest.TestCase):
         open_files = self.system.dump_loaded_files()
         self.assertTrue(len(open_files) > 0)
         # Check we pulled at least one file from /bin/
-        with ZipFile(self.zip_path) as z:
+        with ZipFile(self.system.output_path) as z:
             binary_files = [binary for binary in z.namelist() if ("/bin/" in binary in binary.lower())]
             self.assertGreater(len(binary_files), 0)
                         

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -6,12 +6,11 @@ from varc_core.systems import BaseSystem, acquire_system
 
 class TestBaseCases(unittest.TestCase):
     system: BaseSystem
-    zip_path: str
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.system = acquire_system()
-        cls.zip_path = cls.system.acquire_volatile()
+        cls.system.acquire_volatile()
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -27,5 +26,5 @@ class TestBaseCases(unittest.TestCase):
 
     def test_got_files(self) -> None:
         # Check we got atleast 10 files
-        with ZipFile(self.zip_path) as z:
+        with ZipFile(self.system.output_path) as z:
             self.assertGreater(len(z.namelist()), 10)

--- a/varc_core/systems/__init__.py
+++ b/varc_core/systems/__init__.py
@@ -10,7 +10,8 @@ def acquire_system(
     include_memory: bool = True,
     include_open: bool = True,
     extract_dumps: bool = False,
-    yara_file:  Optional[str] = None
+    yara_file: Optional[str] = None,
+    output_path: Optional[str] = None
 ) -> BaseSystem:
     """Returns the either a windows or linux system or osx system
 
@@ -20,12 +21,12 @@ def acquire_system(
     logging.info(f"Operating System is: {platform}")
     if platform == "linux" or platform == "linux2":
         from varc_core.systems.linux import LinuxSystem
-        return LinuxSystem(include_memory, include_open, extract_dumps, yara_file)
+        return LinuxSystem(include_memory, include_open, extract_dumps, yara_file, output_path=output_path)
     elif platform == "darwin":
         from varc_core.systems.osx import OsxSystem
-        return OsxSystem(include_memory, include_open, extract_dumps)
+        return OsxSystem(include_memory, include_open, extract_dumps, output_path=output_path)
     elif platform == "win32":
         from varc_core.systems.windows import WindowsSystem
-        return WindowsSystem(include_memory, include_open, extract_dumps, yara_file)
+        return WindowsSystem(include_memory, include_open, extract_dumps, yara_file, output_path=output_path)
     else:
         raise MissingOperatingSystemInfo()

--- a/varc_core/systems/base_system.py
+++ b/varc_core/systems/base_system.py
@@ -296,12 +296,10 @@ class BaseSystem:
             if screenshot_image:
                 zip_file.writestr(f"{self.get_machine_name()}-{self.timestamp}.png", screenshot_image)
             for key, value in table_data.items():
-                with zip_file.open(f"{key}.json", 'w') as json_file:
-                    json_file.write(value.encode())
+                zip_file.writestr(f"{key}.json", value.encode())
             if self.network_log:
                 logging.info("Adding Netstat Data")
-                with zip_file.open("netstat.log", 'w') as network_file:
-                    network_file.write("\r\n".join(self.network_log).encode())
+                zip_file.writestr("netstat.log", "\r\n".join(self.network_log).encode())
             if self.include_open and self.dumped_files:
                 for file_path in self.dumped_files:
                     logging.info(f"Adding open file {file_path}")

--- a/varc_core/systems/base_system.py
+++ b/varc_core/systems/base_system.py
@@ -18,9 +18,9 @@ import time
 import zipfile
 from base64 import b64encode
 from datetime import datetime
-from typing import IO, Any, List, Optional, Union
+from typing import Any, List, Optional, Union
 
-import lz4.frame
+import lz4.frame  # type: ignore
 import mss
 import psutil
 from tqdm import tqdm
@@ -38,22 +38,22 @@ _MAX_OPEN_FILE_SIZE = 10000000  # 10 Mb max dumped filesize
 
 class _TarLz4Wrapper:
 
-    def __init__(self, path) -> None:
+    def __init__(self, path: str) -> None:
         self._lz4 = lz4.frame.open(path, 'wb')
         self._tar = tarfile.open(fileobj=self._lz4, mode="w")
 
-    def writestr(self, path: str, value: Union[str, bytes]):
+    def writestr(self, path: str, value: Union[str, bytes]) -> None:
         info = tarfile.TarInfo(path)
         info.size = len(value)
         self._tar.addfile(info, io.BytesIO(value if isinstance(value, bytes) else value.encode()))
 
-    def write(self, path: str, arcname: str):
+    def write(self, path: str, arcname: str) -> None:
         self._tar.add(path, arcname)
 
-    def __enter__(self):
+    def __enter__(self) -> "_TarLz4Wrapper":
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
         self._tar.close()
         self._lz4.close()
 


### PR DESCRIPTION
Compressing with `.tar.lz4` is significantly faster than zip (at the cost of slightly less compression). Changes in this PR:
 - Move handling for output_path into the __init__ instead of mutating state in acquire_volatile
 - Replace open entry and writing string to it with `writestr`
 - Create a wrapper around tar and lz4 with limited part of ZipFile interface and use depending on output path extension