### PR TITLE
Fix some issues in lz4 support

### DIFF
--- a/varc_core/systems/base_system.py
+++ b/varc_core/systems/base_system.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import os.path
+from pathlib import Path
 import socket
 import tarfile
 import time
@@ -112,6 +113,15 @@ class BaseSystem:
 
         if self.yara_file and not self.include_memory and _YARA_AVAILABLE:
             logging.info("YARA hits will be recorded only since include_memory is not selected.")
+
+        if self.include_memory:
+            if self.yara_file:
+                self.yara_scan()
+            self.dump_processes()
+
+            if self.extract_dumps:
+                from varc_core.utils import dumpfile_extraction
+                dumpfile_extraction.extract_dumps(Path(self.output_path))
 
     def get_network(self) -> List[str]:
         """Get active network connections
@@ -381,3 +391,5 @@ class BaseSystem:
         else:
             logging.info("No YARA rules were triggered. Nothing will be written to the output archive.")
 
+    def dump_processes(self) -> None:
+        raise NotImplementedError()

--- a/varc_core/systems/base_system.py
+++ b/varc_core/systems/base_system.py
@@ -99,8 +99,6 @@ class BaseSystem:
             raise ValueError(
                 "Only one of Process name or Process ID (PID) can be used. Please re-run using one or the other.")
         
-        self.acquire_volatile()
-
         if self.yara_file:
             if not _YARA_AVAILABLE:
                 logging.error("YARA not available. yara-python is required and is either not installed or not functioning correctly.")
@@ -113,15 +111,21 @@ class BaseSystem:
 
         if self.yara_file and not self.include_memory and _YARA_AVAILABLE:
             logging.info("YARA hits will be recorded only since include_memory is not selected.")
+        
+        with self._open_output() as output:
+           
+            self.acquire_volatile(output)
 
-        if self.include_memory:
-            if self.yara_file:
-                self.yara_scan()
-            self.dump_processes()
+            if self.include_memory:
+                if self.yara_file:
+                    self.yara_scan(output)
+                self.dump_processes(output)
 
-            if self.extract_dumps:
-                from varc_core.utils import dumpfile_extraction
-                dumpfile_extraction.extract_dumps(Path(self.output_path))
+        if self.extract_dumps:
+            if not self.output_path.endswith('.zip'):
+                logging.warning('extract_dumps only supported with zip output')
+            from varc_core.utils import dumpfile_extraction
+            dumpfile_extraction.extract_dumps(Path(self.output_path))
 
     def get_network(self) -> List[str]:
         """Get active network connections
@@ -311,7 +315,7 @@ class BaseSystem:
             logging.error("Unable to take screenshot")
         return None
 
-    def acquire_volatile(self) -> None:
+    def acquire_volatile(self, output_file: Union[zipfile.ZipFile, _TarLz4Wrapper]) -> None:
         """Acquire volatile data into a zip file
         This is called by all OS's
         """
@@ -327,27 +331,26 @@ class BaseSystem:
         else:
             screenshot_image = None
 
-        with self._open_output() as output_file:
-            if screenshot_image:
-                output_file.writestr(f"{self.get_machine_name()}-{self.timestamp}.png", screenshot_image)
-            for key, value in table_data.items():
-                output_file.writestr(f"{key}.json", value.encode())
-            if self.network_log:
-                logging.info("Adding Netstat Data")
-                output_file.writestr("netstat.log", "\r\n".join(self.network_log).encode())
-            if self.include_open and self.dumped_files:
-                for file_path in self.dumped_files:
-                    logging.info(f"Adding open file {file_path}")
-                    try:
-                        if os.path.getsize(file_path) > _MAX_OPEN_FILE_SIZE:
-                            logging.warning(f"Skipping file as too large {file_path}")
-                        else:
-                            try:
-                                output_file.write(file_path, strip_drive(f"./collected_files/{file_path}"))
-                            except PermissionError:
-                                logging.warn(f"Permission denied copying {file_path}")
-                    except FileNotFoundError:
-                        logging.warning(f"Could not open {file_path} for reading")
+        if screenshot_image:
+            output_file.writestr(f"{self.get_machine_name()}-{self.timestamp}.png", screenshot_image)
+        for key, value in table_data.items():
+            output_file.writestr(f"{key}.json", value.encode())
+        if self.network_log:
+            logging.info("Adding Netstat Data")
+            output_file.writestr("netstat.log", "\r\n".join(self.network_log).encode())
+        if self.include_open and self.dumped_files:
+            for file_path in self.dumped_files:
+                logging.info(f"Adding open file {file_path}")
+                try:
+                    if os.path.getsize(file_path) > _MAX_OPEN_FILE_SIZE:
+                        logging.warning(f"Skipping file as too large {file_path}")
+                    else:
+                        try:
+                            output_file.write(file_path, strip_drive(f"./collected_files/{file_path}"))
+                        except PermissionError:
+                            logging.warn(f"Permission denied copying {file_path}")
+                except FileNotFoundError:
+                    logging.warning(f"Could not open {file_path} for reading")
 
     def _open_output(self) -> Union[zipfile.ZipFile, _TarLz4Wrapper]:
         if self.output_path.endswith('.tar.lz4'):
@@ -355,7 +358,7 @@ class BaseSystem:
         else:
             return zipfile.ZipFile(self.output_path, 'a', compression=zipfile.ZIP_DEFLATED)
 
-    def yara_scan(self) -> None:
+    def yara_scan(self, output_file: Union[zipfile.ZipFile, _TarLz4Wrapper]) -> None:
         def yara_hit_callback(hit: dict) -> Any:
             self.yara_results.append(hit)
             if self.include_memory:
@@ -367,7 +370,6 @@ class BaseSystem:
         if not _YARA_AVAILABLE:
             return None
 
-        archive_out = self.output_path
         for proc in tqdm(self.process_info, desc="YARA scan progess", unit=" procs"):
             pid = proc["Process ID"]
             p_name = proc["Name"]
@@ -385,11 +387,11 @@ class BaseSystem:
             combined_yara_results = []
             for yara_hit in self.yara_results:
                 combined_yara_results.append(self.yara_hit_readable(yara_hit))
-            with zipfile.ZipFile(archive_out, 'a', compression=zipfile.ZIP_DEFLATED) as zip_file:
-                zip_file.writestr("yara_results.json", self.dict_to_json(combined_yara_results))
-                logging.info("YARA scan results written to yara_results.json in output archive.")
+                
+            output_file.writestr("yara_results.json", self.dict_to_json(combined_yara_results))
+            logging.info("YARA scan results written to yara_results.json in output archive.")
         else:
             logging.info("No YARA rules were triggered. Nothing will be written to the output archive.")
 
-    def dump_processes(self) -> None:
+    def dump_processes(self, output_file: Union[zipfile.ZipFile, _TarLz4Wrapper]) -> None:
         raise NotImplementedError()

--- a/varc_core/systems/linux.py
+++ b/varc_core/systems/linux.py
@@ -5,10 +5,10 @@ import zipfile
 from os import getpid, sep
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 from tqdm import tqdm
-from varc_core.systems.base_system import BaseSystem
+from varc_core.systems.base_system import _TarLz4Wrapper, BaseSystem
 
 # based on https://stackoverflow.com/questions/48897687/why-does-the-syscall-process-vm-readv-sets-errno-to-success and PymemLinux library
 
@@ -83,51 +83,49 @@ class LinuxSystem(BaseSystem):
 
         return buff.raw
 
-    def dump_processes(self) -> None:
+    def dump_processes(self, output_file: Union[zipfile.ZipFile, _TarLz4Wrapper]) -> None:
         """Dumps all processes to temp files, adds temp file to output archive then removes the temp file"""
-        archive_out = self.output_path
         own_pid = getpid()
-        with zipfile.ZipFile(archive_out, "a", compression=zipfile.ZIP_DEFLATED) as zip_file:
-            try:
-                for proc in tqdm(self.process_info, desc="Process dump progess", unit=" procs"):
-                    # If scanning with YARA, only dump processes if they triggered a rule
-                    if self.yara_hit_pids:
-                        if proc["Process ID"] not in self.yara_hit_pids or proc["Process ID"] == own_pid:
-                            continue
-                    pid = proc["Process ID"]
-                    p_name = proc["Name"]
-                    maps = self.parse_mem_map(pid, p_name)
-                    if not maps:
+        try:
+            for proc in tqdm(self.process_info, desc="Process dump progess", unit=" procs"):
+                # If scanning with YARA, only dump processes if they triggered a rule
+                if self.yara_hit_pids:
+                    if proc["Process ID"] not in self.yara_hit_pids or proc["Process ID"] == own_pid:
                         continue
-                    with NamedTemporaryFile(mode="w+b", buffering=0, delete=True) as tmpfile:
-                        try:
-                            for map in maps:
-                                page_start = map[0]
-                                page_len = map[1] - map[0]
-                                if page_len > _MAX_VIRTUAL_PAGE_CHUNK:
-                                    sub_chunk_count, final_chunk_size = divmod(page_len, _MAX_VIRTUAL_PAGE_CHUNK)
-                                    page_len = int(page_len / sub_chunk_count)
-                                    for sc in range(0, sub_chunk_count):
-                                        mem_page_content = self.read_bytes(pid, page_start, page_len)
-                                        if mem_page_content:
-                                            tmpfile.write(mem_page_content)
-                                        page_start = page_start + _MAX_VIRTUAL_PAGE_CHUNK
-                                    mem_page_content = self.read_bytes(pid, page_start, final_chunk_size)
-                                    if mem_page_content:
-                                        tmpfile.write(mem_page_content)
-                                else:
+                pid = proc["Process ID"]
+                p_name = proc["Name"]
+                maps = self.parse_mem_map(pid, p_name)
+                if not maps:
+                    continue
+                with NamedTemporaryFile(mode="w+b", buffering=0, delete=True) as tmpfile:
+                    try:
+                        for map in maps:
+                            page_start = map[0]
+                            page_len = map[1] - map[0]
+                            if page_len > _MAX_VIRTUAL_PAGE_CHUNK:
+                                sub_chunk_count, final_chunk_size = divmod(page_len, _MAX_VIRTUAL_PAGE_CHUNK)
+                                page_len = int(page_len / sub_chunk_count)
+                                for sc in range(0, sub_chunk_count):
                                     mem_page_content = self.read_bytes(pid, page_start, page_len)
                                     if mem_page_content:
                                         tmpfile.write(mem_page_content)
-                            zip_file.write(tmpfile.name, f"process_dumps{sep}{p_name}_{pid}.mem")
-                        except PermissionError:
-                            logging.warning(f"Permission denied opening process memory for {p_name} (pid {pid}). Cannot dump this process.")
-                            continue
-                        except OSError as oserror:
-                            logging.warning(f"Error opening process memory page for {p_name} (pid {pid}). Error was {oserror}. Dump may be incomplete.")
-                            pass
-            except MemoryError:
-                logging.warning("Exceeded available memory, skipping further memory collection")
+                                    page_start = page_start + _MAX_VIRTUAL_PAGE_CHUNK
+                                mem_page_content = self.read_bytes(pid, page_start, final_chunk_size)
+                                if mem_page_content:
+                                    tmpfile.write(mem_page_content)
+                            else:
+                                mem_page_content = self.read_bytes(pid, page_start, page_len)
+                                if mem_page_content:
+                                    tmpfile.write(mem_page_content)
+                        output_file.write(tmpfile.name, f"process_dumps{sep}{p_name}_{pid}.mem")
+                    except PermissionError:
+                        logging.warning(f"Permission denied opening process memory for {p_name} (pid {pid}). Cannot dump this process.")
+                        continue
+                    except OSError as oserror:
+                        logging.warning(f"Error opening process memory page for {p_name} (pid {pid}). Error was {oserror}. Dump may be incomplete.")
+                        pass
+        except MemoryError:
+            logging.warning("Exceeded available memory, skipping further memory collection")
                         
 
         logging.info(f"Dumping processing has completed. Output file is located: {archive_out}")

--- a/varc_core/systems/linux.py
+++ b/varc_core/systems/linux.py
@@ -35,24 +35,6 @@ _MAX_VIRTUAL_PAGE_CHUNK = 256 * 1000**2 # max number of megabytes that will be r
 
 
 class LinuxSystem(BaseSystem):
-    
-    def __init__(
-        self,
-        include_memory: bool,
-        include_open: bool,
-        extract_dumps: bool,
-        yara_file: Optional[str],
-        **kwargs: Any
-    ) -> None:
-        super().__init__(include_memory=include_memory, include_open=include_open, extract_dumps=extract_dumps, yara_file=yara_file, **kwargs)
-        if self.include_memory:
-            if self.yara_file:
-                self.yara_scan()
-            self.dump_processes()
-
-            if self.extract_dumps:
-                from varc_core.utils import dumpfile_extraction
-                dumpfile_extraction.extract_dumps(Path(self.output_path))
 
     def parse_mem_map(self, pid: int, p_name: str) -> List[Tuple[int, int]]:
         """Returns a list of (start address, end address) tuples of the regions of process memory that are mapped

--- a/varc_core/systems/linux.py
+++ b/varc_core/systems/linux.py
@@ -36,6 +36,16 @@ _MAX_VIRTUAL_PAGE_CHUNK = 256 * 1000**2 # max number of megabytes that will be r
 
 class LinuxSystem(BaseSystem):
 
+    def __init__(
+        self,
+        include_memory: bool,
+        include_open: bool,
+        extract_dumps: bool,
+        yara_file: Optional[str],
+        **kwargs: Any
+    ) -> None:
+        super().__init__(include_memory=include_memory, include_open=include_open, extract_dumps=extract_dumps, yara_file=yara_file, **kwargs)
+
     def parse_mem_map(self, pid: int, p_name: str) -> List[Tuple[int, int]]:
         """Returns a list of (start address, end address) tuples of the regions of process memory that are mapped
         

--- a/varc_core/systems/windows.py
+++ b/varc_core/systems/windows.py
@@ -18,6 +18,16 @@ if platform == "win32": # dont try to import on linux
 
 class WindowsSystem(BaseSystem):
 
+    def __init__(
+        self,
+        include_memory: bool,
+        include_open: bool,
+        extract_dumps: bool,
+        yara_file: Optional[str],
+        **kwargs: Any
+    ) -> None:
+        super().__init__(include_memory=include_memory, include_open=include_open, extract_dumps=extract_dumps, yara_file=yara_file, **kwargs)
+
     def read_process(self, handle: int, address: int) -> Tuple[Optional[bytes], int]:
         """ Read a process. Based on pymems pattern module
 

--- a/varc_core/systems/windows.py
+++ b/varc_core/systems/windows.py
@@ -15,27 +15,8 @@ if platform == "win32": # dont try to import on linux
 
    import pymem
 
+
 class WindowsSystem(BaseSystem):
-    """
-    """
-
-    def __init__(
-        self,
-        include_memory: bool,
-        include_open: bool,
-        extract_dumps: bool,
-        yara_file: Optional[str],
-        **kwargs: Any
-    ) -> None:
-        super().__init__(include_memory=include_memory, include_open=include_open, extract_dumps=extract_dumps, yara_file=yara_file, **kwargs)
-        if self.include_memory:
-            if self.yara_file:
-                self.yara_scan()
-            self.dump_processes()
-
-            if self.extract_dumps:
-                from varc_core.utils import dumpfile_extraction
-                dumpfile_extraction.extract_dumps(Path(self.output_path))
 
     def read_process(self, handle: int, address: int) -> Tuple[Optional[bytes], int]:
         """ Read a process. Based on pymems pattern module


### PR DESCRIPTION
Ran into some issues with lz4 support where we attempt to reopen the file for writing as a zip later in the process. Suggest reviewing commits separately since this includes some initial tidying up:
 - Move fields from LinuxSystem to constants/locals, making LinuxSystem and WindowsSystem __init__s identical
 - Dedup __init__ methods
 - Open output file once and have all methods write to it instead of repeatedly opening for appending